### PR TITLE
Update processing state before we start processing

### DIFF
--- a/update.js
+++ b/update.js
@@ -22,10 +22,10 @@ const process = async () => {
   // Now check the queue and pick a file to process
   let toProcess = await getReplicationToProcess();
   while (toProcess) {
+    await setProcessedState(toProcess);
     console.log(`Processing replication file ${toProcess}`);
     await run(toProcess);
     console.log(`Finished processing replication file ${toProcess}`);
-    await setProcessedState(toProcess);
     toProcess = await getReplicationToProcess();
   }
 };


### PR DESCRIPTION
this prevent parallel workers from picking up duplicate work