### PR TITLE
Skip uploading tag-changes if OSMCha API token is not configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,13 @@ const run = async (replicationFileId) => {
   await Promise.all(changesetList.map(uploadToS3));
   console.log('Uploaded all changesets to s3');
 
-  await Promise.all(changesetList.map(postTagChanges));
-  console.log('Posted all changesets tagChanges to OSMCha API');
+  if (process.env.OsmchaAdminToken) {
+    await Promise.all(changesetList.map(postTagChanges));
+    console.log('Posted all changesets tagChanges to OSMCha API');
+  } else {
+    console.log('OSMCha API Token is not configured; skipping postTagChanges step.')
+  }
+
   console.timeEnd(`TIME ${replicationFileId}`);
 };
 

--- a/lib/tagChanges.js
+++ b/lib/tagChanges.js
@@ -5,10 +5,6 @@ const { OSMCHA_URL } = require('./constants');
 const { request } = require('../util/request');
 
 const postTagChanges = async (changeset) => {
-  if (!process.env.OsmchaAdminToken) {
-    console.log('OSMCha API Token is not configured.')
-  }
-
   try {
     const changesetId = changeset.metadata.id;
     const url = `${OSMCHA_URL}/changesets/${changesetId}/tag-changes/`;


### PR DESCRIPTION
The job of uploading tag changes is now handled by https://github.com/OSMCha/changeset-adiffs-worker, so we can turn off uploading them from the osm-adiff-service. This PR makes it possible to do this by omitting the `OsmchaAdminToken` env variable.

Once this is merged I'll modify the osmcha-deploy configuration to omit this variable.